### PR TITLE
using "color white, name ca" instead of "set cartoon_color, white"

### DIFF
--- a/HPPNcolor_v1.pml
+++ b/HPPNcolor_v1.pml
@@ -52,5 +52,7 @@ disable Gs
 disable Ps
 disable As
 disable Cs
-set cartoon_color, white
-set cartoon_color, tv_green, Gs
+color white, name ca
+color tv_green, name ca and Gs
+#set cartoon_color, white
+#set cartoon_color, tv_green, Gs


### PR DESCRIPTION
I made a small modification to color cartoon by specifying ca atoms instead of "set cartoon_color, white".
This makes it easier to change the color of cartoon after using HPPNcolor.pml.

Please ignore this pull request if this does not align your intention. 